### PR TITLE
Docs reorg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# GeeBeam
+# geebeam
 
 [![Testing + Linting](https://github.com/kysolvik/geebeam/actions/workflows/pytest-lint.yml/badge.svg)](https://github.com/kysolvik/geebeam/actions/workflows/pytest-lint.yml)
 
-Google Earth Engine + Apache Beam for building geospatial training datasets
+Google Earth Engine and Apache Beam for building geospatial training datasets.
 
 ## Purpose:
 
-GeeBeam is a lightweight library for building and executing Apache Beam pipelines that download data "chips" from Google Earth Engine and write them to TensorFlow records for model training.
+geebeam is a lightweight library for building and executing Apache Beam pipelines that download data "chips" from Google Earth Engine and write them to a variety of common data formats (GeoTIFF, WebDataset, TensorFlow Dataset).
 
 The user defines the Earth Engine images they want to download chips from using the Python earthengine-api. geebeam then serialized the graph-definition of the images so they can be passed to the Beam workers.
 
-The pipelines can be run locally or on Google Cloud Dataflow. (Note: currently local jobs are limited to short-running tasks due to grpc "Deadline Exceeded" error).
+The pipelines are automatically parallelized and can be run locally or on Google Cloud Dataflow.
 
 
 ## Install:
@@ -132,5 +132,8 @@ See [DataFlow documentation on specifying network and subnetwork](https://docs.c
 ## Alternatives:
 
 - [GeeFlow](https://github.com/google-deepmind/geeflow): Google DeepMind's GeeFlow fulfills a similar purpose. It is more flexible, allowing for more user control of data processing, reprojection, and writing, but slower and no longer actively maintained. With the goal of meeting *most* users' needs, GeeBeam is designed to be easier and quicker to use, but allows from more limited data transformations.
-- Export training data to Google Cloud Storage then download chips from there: This works, but if you need to get data from many different datasets it's slow to export all that data to Cloud Storage and can be expensive to store it there if you don't delete it quickly. This also uses a lot of Earth Engine compute hours, which are now subject to stricter monthly limits.
-- [Xee](https://github.com/google/Xee): Xee allows for accessing Earth Engine objects as xarray.Datasets. You could use this to define a xarray.Dataset and download "chips" from it, but geebeam interfaces with Beam to automatically parallelize this task and export to Tensorflow records.
+- Export training data to Google Cloud Storage then download chips from there: This works, but if you need to get data from many different datasets it's slow to export all that data to Cloud Storage and can be expensive to store it there if you don't delete it quickly. This also uses unnecessary Earth Engine compute hours, which are now subject to stricter monthly limits.
+- [Xee](https://github.com/google/Xee): Xee is a great package that allows for accessing Earth Engine objects as xarray.Datasets. You could use this to define a xarray.Dataset and download "chips" from it, but geebeam interfaces with Beam to automatically parallelize this task and export to a variety of common data formats (GeoTIFF, WebDataset, TensorFlow Datasets)
+
+## Disclaimer: 
+geebeam is a third-party library and is not affiliated with or endorsed by Google or the Apache Software Foundation.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ extensions = [
 ]
 autoapi_dirs = ['../src/geebeam']
 
-autoapi_options = ['members', 'show-module-summary', 'imported-members']
+autoapi_options = ['members', 'show-module-summary']
 
 autodoc_typehints = 'description'
 autoapi_member_order = 'groupwise'

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -10,7 +10,7 @@ tool — and everything you need to use ``geebeam`` for your work!
 
    This tutorial runs locally. We'll keep the sample count small (10 patches)
    so everything finishes in under a minute or so. For info on running on
-   DataFlow, see :ref:`scaling-up`.
+   DataFlow, see :doc:`scaling_up`.
 
 What is ``geebeam``?
 --------------------
@@ -62,7 +62,7 @@ step:
 
    earthengine authenticate
 
-This opens a browser window to login and save save credentials locally. You only 
+This opens a browser window to login and save credentials locally. You only
 need to do this once.
 
 You also need to tell Earth Engine which Google Cloud project to use. 
@@ -135,7 +135,7 @@ You will see some Apache Beam log lines scroll by. When it finishes the
 
 **What do ``patch_size`` and ``scale`` mean?**
 Each chip covers ``128 × 30 m = 3.84 km`` on a side. Increasing ``patch_size``
-gives more spatial context. Increasing ``scale`` also gives more spatial_context
+gives more spatial context. Increasing ``scale`` also gives more spatial context
 but at the cost of lower resolution/detail.
 
 **What does ``position`` do?**
@@ -144,8 +144,8 @@ By default each sampling point is the *center* of its patch
 ``"top-right"``, ``"bottom-left"``, or ``"bottom-right"`` if your workflow
 requires the coordinate to refer to a specific corner.
 
-**Why is ``ls8_composite`` wrapped in an list ``[]``?**
-``image_list`` must be a Python list** of ``ee.Image`` objects, even
+**Why is ``ls8_composite`` wrapped in a list ``[]``?**
+``image_list`` must be a Python list of ``ee.Image`` objects, even
 when you only have one image. This is how ``geebeam`` knows how to split
 bands across workers when needed (see :doc:`split_processing`). If you pass 
 a single ``ee.Image``, ``geebeam`` will wrap it in a list and keep going
@@ -245,7 +245,7 @@ What's next
 
 - **Other output formats** — pass ``output_type="webdataset"`` to produce a 
   `WebDataset tar <https://github.com/webdataset/webdataset>`_
-  or output_type="tfds"` (requires ``pip install geebeam[tensorflow]``) to 
+  or ``output_type="tfds"`` (requires ``pip install geebeam[tensorflow]``) to
   write as a Tensorflow dataset. See :doc:`output_types` for more info.
 - **Scaling up with DataFlow** — geebeam makes it super easy to run large 
   pipelines on Google Cloud Dataflow by providing pre-built Docker images.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -147,7 +147,7 @@ requires the coordinate to refer to a specific corner.
 **Why is ``ls8_composite`` wrapped in an list ``[]``?**
 ``image_list`` must be a Python list** of ``ee.Image`` objects, even
 when you only have one image. This is how ``geebeam`` knows how to split
-bands across workers when needed (see `:ref:_split-processing`). If you pass 
+bands across workers when needed (see :doc:`split_processing`). If you pass 
 a single ``ee.Image``, ``geebeam`` will wrap it in a list and keep going
 (with a warning). Currently, ``ee.ImageCollection`` objects are NOT supported.
 
@@ -172,7 +172,7 @@ list. The ``metadata`` Parquet file records the sampling location (``x``, ``y``)
 the patch origin (``x_topleft``, ``y_topleft``), the split assignment, and the
 file path for each chip.
 
-Open a chip with rasterio to confirm it looks right:
+Open a chip with rasterio to confirm it looks right (you may need to install matplotlib):
 
 .. code-block:: python
 
@@ -208,7 +208,7 @@ You can also read the metadata table:
    print(df[["id", "x", "y", "x_topleft", "y_topleft", "split", "image_path"]])
 
 
-Adding a second image
+Step 4. Adding a second image
 ----------------------
 
 With ``geebeam``, downloading many datasets in a single pipeline is just 
@@ -240,99 +240,27 @@ are stacked into the same chip/patch files:
 
 The output TIFFs will now contain 7 bands (6 Landsat + 1 LULC).
 
-.. _split-processing:
-
-Splitting processing to avoid the 50 MB limit
-----------------------------------------------
-
-Each call to Earth Engine's ``computePixels`` API is capped at **50 MB** per
-response. By default ``geebeam`` combines all bands from all images in
-``image_list`` into a single request per patch, so you can hit this limit with
-large patches or many bands.
-
-A rough estimate of response size:
-
-.. code-block:: text
-
-   response_bytes ≈ patch_size × patch_size × n_bands × bytes_per_pixel
-   e.g. 512 × 512 × 48 bands × 4 bytes (float32) ≈ 50 MB
-
-If hit an error saying that you've exceeded the max size, pass 
-``split_processing=True``. This makes ``geebeam`` run **one** ``computePixels``
-request **per** image in ``image_list`` instead of one combined request,
-so each individual call stays under the limit:
-
-.. code-block:: python
-
-   geebeam.sample_and_run_pipeline(
-       image_list=[ls8_composite, mb_lulc],
-       split_processing=True,    # one EE request per image
-       sampling_region=ee.Geometry.Rectangle(-55.0, -12.0, -50.0, -16.0),
-       n_sample=10,
-       patch_size=512,
-       scale=30,
-       crs="EPSG:4326",
-       project=PROJECT_ID,
-       output_path="./tutorial_output_split/",
-   )
-
-The output is identical — bands from all images are still merged into the same
-chip files. The only difference is the number of round-trips to Earth Engine
-per patch: one per image rather than one total. This is slower, so unless you 
-run into errors it's better to leave it at the default (``False``).
-
-
-.. _scaling-up:
-
-Scaling up with Dataflow
--------------------------
-
-The local runner is useful for development and small jobs. For bigger
-workloads (e.g. thousands of patches or large images), you can run on Google Cloud
-Dataflow. Write your ``run_pipeline()`` inside a script and run it with Dataflow
-runner options:
-
-.. code-block:: bash
-
-   python my_pipeline.py \
-       --runner=DataflowRunner \
-       --region=us-east1 \
-       --worker_zone=us-east1-b \
-       --max_num_workers=8 \
-       --temp_location=gs://my-bucket/tmp/ \
-       --sdk_container_image=kysolvik/geebeam:|version| \
-       --machine_type=n2-highmem-2 \
-       --experiments=use_runner_v2
-
-Set ``output_path`` to a ``gs://`` path and ``geebeam`` will write directly to
-Google Cloud Storage. See the
-`Dataflow documentation <https://cloud.google.com/dataflow/docs>`_ for full
-option reference.
-
-.. tip::
-
-   Test your script locally first with ``--runner=DirectRunner`` before
-   submitting to Dataflow. This catches serialisation errors and EE API issues
-   without spending cloud credits.
-
-
 What's next
 ------------
 
-- **Grid sampling** — use :func:`~geebeam.grid_and_run_pipeline` to sample on a
-  regular grid rather than randomly. Useful when you need complete spatial
-  coverage without gaps. You can also overlap by controlling the ``stride`` arg.
-- **Custom sampling points** — use :func:`~geebeam.run_pipeline` directly
-  and pass your own ``sampling_points`` as a Geopandas GeoDataFrame,
-  Pandas DataFrame, or Earth Engine Feature Collection (but they *must* have
-  point geometries). The ':mod:`~geebeam.sampler` submodule also has more options
-  for sampling, including custom dataset splits (e.g. train/val/test).
 - **Other output formats** — pass ``output_type="webdataset"`` to produce a 
   `WebDataset tar <https://github.com/webdataset/webdataset>`_
   or output_type="tfds"` (requires ``pip install geebeam[tensorflow]``) to 
   write as a Tensorflow dataset. See :doc:`output_types` for more info.
+- **Scaling up with DataFlow** — geebeam makes it super easy to run large 
+  pipelines on Google Cloud Dataflow by providing pre-built Docker images.
+  See :doc:`scaling_up` for more.
+- **Custom and gridded sampling** — use :func:`~geebeam.run_pipeline` directly
+  and pass your own ``sampling_points`` as a Geopandas GeoDataFrame,
+  Pandas DataFrame, or Earth Engine Feature Collection (but they *must* have
+  point geometries). Or use :func:`~geebeam.grid_and_run_pipeline` to sample on a
+  regular grid rather than randomly for when you need complete spatial
+  coverage without gaps. See :mod:`~geebeam.sampler`
+  for more info, including custom dataset splits (e.g. train/val/test).
+- **Split processing of large patches** — Earth Engine limits single request sizes 
+  to 50 MB, but geebeam lets you split processing: :doc:`split_processing`
 - **API reference** — full parameter documentation for all three pipeline
-  functions is on the :doc:`autoapi/geebeam/index` page.
+  functions and the sampler module is on the :mod:`~geebeam` page.
 
 
 Get Help / Contribute

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,8 @@ Contents
 
    getting_started
    output_types
+   scaling_up
+   split_processing
 
 .. note::
 

--- a/docs/output_types.rst
+++ b/docs/output_types.rst
@@ -2,7 +2,7 @@ Output Types
 ============
 
 geebeam supports four output formats, selected with the ``output_type``
-argument. The right choice depends on your downstream tooling:
+argument. The right choice depends on your downstream use:
 
 .. list-table::
    :header-rows: 1
@@ -14,19 +14,19 @@ argument. The right choice depends on your downstream tooling:
      - Extra dependencies required?
    * - GeoTIFF
      - ``"tiff"`` *(default)*
-     - GIS tools, rasterio, any language
+     - GIS tools (rasterio, QGIS)
      - No
    * - WebDataset
      - ``"webdataset"``
-     - PyTorch / streaming data pipelines
+     - PyTorch pipelines
      - No
    * - TensorFlow Datasets
      - ``"tfds"``
-     - TensorFlow ``tf.data`` pipelines
+     - TensorFlow pipelines
      - Yes (``geebeam[tensorflow]``)
    * - TFRecord
      - ``"tfrecord"``
-     - Automatic dataset statistics with TFDV
+     - Automatic dataset stats
      - Yes (``geebeam[tensorflow]``)
 
 
@@ -182,7 +182,7 @@ TFRecord
    specifically need to compute dataset statistics with
    `TensorFlow Data Validation <https://www.tensorflow.org/tfx/data_validation/get_started>`_
    (TFDV) — that is the only thing this format provides over ``"tfds"``. 
-   The TFRecord ``output_type`` comes some drawbacks (no standard loading API,
+   The TFRecord ``output_type`` comes with some drawbacks (no standard loading API,
    harder to inspect, needs semi-manual schema coupling).
 
 **Install:**

--- a/docs/scaling_up.rst
+++ b/docs/scaling_up.rst
@@ -20,7 +20,7 @@ runner options:
 
 Set ``output_path`` to a ``gs://`` path and ``geebeam`` will write directly to
 Google Cloud Storage. See the
-`Dataflow documentation <https://cloud.google.com/dataflow/docs>`_ for full
+`Dataflow documentation <https://cloud.google.com/dataflow/docs>`_ for full details.
 
 Make sure to replace [version] in the sdk_container_image URI with the geebeam version 
 number installed on your system:

--- a/docs/scaling_up.rst
+++ b/docs/scaling_up.rst
@@ -1,0 +1,51 @@
+Scaling up with Dataflow
+========================
+
+The local runner is useful for development and small jobs. For bigger
+workloads (e.g. thousands of patches or large images), you can run on Google Cloud
+Dataflow (note: Dataflow is a billed resource). Write your ``run_pipeline()`` inside a script and run it with Dataflow
+runner options:
+
+.. code-block:: bash
+
+   python my_pipeline.py \
+       --runner=DataflowRunner \
+       --region=us-east1 \
+       --worker_zone=us-east1-b \
+       --max_num_workers=8 \
+       --temp_location=gs://[my-bucket]/tmp/ \
+       --sdk_container_image=kysolvik/geebeam:[version] \
+       --machine_type=n2-highmem-2 \
+       --experiments=use_runner_v2
+
+Set ``output_path`` to a ``gs://`` path and ``geebeam`` will write directly to
+Google Cloud Storage. See the
+`Dataflow documentation <https://cloud.google.com/dataflow/docs>`_ for full
+
+Make sure to replace [version] in the sdk_container_image URI with the geebeam version 
+number installed on your system:
+
+.. code-block:: bash
+
+   python -c "import geebeam;print(geebeam.__version__)"
+
+.. tip::
+
+   Test a small sample of your script locally first with ``--runner=DirectRunner``
+   before submitting to Dataflow. This catches errors without using Dataflow 
+   resources and costing $$$.
+
+
+Common DataFlow gotchas
+-----------------------
+
+1. Before running, you must `enable the DataFlow API on Google Cloud Console <https://console.developers.google.com/apis/api/dataflow.googleapis.com/overview>`_.
+
+2. If you get an error stating "Subnetwork ''... does not have Private Google Access...", you may need to activate it for your subnetwork (replace us-east1 with your region):
+
+
+.. code-block:: bash
+
+   gcloud compute networks subnets update default \
+      --region=us-east1 \
+      --enable-private-ip-google-access

--- a/docs/split_processing.rst
+++ b/docs/split_processing.rst
@@ -13,7 +13,7 @@ A rough estimate of response size:
    response_bytes ≈ patch_size × patch_size × n_bands × bytes_per_pixel
    e.g. 512 × 512 × 48 bands × 4 bytes (float32) ≈ 50 MB
 
-If hit an error saying that you've exceeded the max size, pass 
+If you hit an error saying that you've exceeded the max size, pass
 ``split_processing=True``. This makes ``geebeam`` run **one** ``computePixels``
 request **per** image in ``image_list`` instead of one combined request,
 so each individual call stays under the limit. If you're already only targeting 

--- a/docs/split_processing.rst
+++ b/docs/split_processing.rst
@@ -1,0 +1,53 @@
+Avoiding the 50 MB per-request limit
+==============================================
+
+Each call to Earth Engine's ``computePixels`` API is capped at **50 MB** per
+response. By default ``geebeam`` combines all bands from all images in
+``image_list`` into a single request per patch, so you can hit this limit with
+large patches or many bands.
+
+A rough estimate of response size:
+
+.. code-block:: text
+
+   response_bytes ≈ patch_size × patch_size × n_bands × bytes_per_pixel
+   e.g. 512 × 512 × 48 bands × 4 bytes (float32) ≈ 50 MB
+
+If hit an error saying that you've exceeded the max size, pass 
+``split_processing=True``. This makes ``geebeam`` run **one** ``computePixels``
+request **per** image in ``image_list`` instead of one combined request,
+so each individual call stays under the limit. If you're already only targeting 
+one image, you can split the bands into multiple images. For example, to get an extra large
+patch of the ls8 composite:
+
+.. code-block:: python
+
+  import ee
+  import geebeam
+
+  ee.Initialize(project=PROJECT_ID)
+
+  ls8_collection = ee.ImageCollection("LANDSAT/LC08/C02/T1_L2") \
+      .filterDate("2023-01-01", "2023-12-31")
+
+  ls8_composite = ls8_collection.median()
+
+  ls8_rgb = ls8_composite.select(["SR_B2", "SR_B3", "SR_B4"])
+  ls8_nir_swir = ls8_composite.select(["SR_B5", "SR_B6", "SR_B7"])
+
+  geebeam.sample_and_run_pipeline(
+      image_list=[ls8_rgb, ls8_nir_swir],
+      split_processing=True,  # one EE request per image
+      sampling_region=ee.Geometry.Rectangle(-55.0, -12.0, -50.0, -16.0),
+      n_sample=10,
+      patch_size=1024,
+      scale=30,
+      crs="EPSG:4326",
+      project=PROJECT_ID,
+      output_path="./tutorial_output_split/",
+  )
+
+The output is identical — bands from all images are still merged into the same
+chip files. The only difference is the number of round-trips to Earth Engine
+per patch: one per image rather than one total. This is slower, so unless you 
+run into errors it's better to leave it at the default (``False``).


### PR DESCRIPTION
Split off scaling up and split processing into separate pages, and improved API documentation.