### PR TITLE
Option to align subsets to specific geospatial transform

### DIFF
--- a/examples/geebeam_run.py
+++ b/examples/geebeam_run.py
@@ -1,8 +1,9 @@
 """Execute GEE tile extraction in Beam + Dataflow"""
 
 import ee
-import geebeam
 import google
+
+import geebeam
 
 # Get default project id from environment (or specify PROJECT_ID manually)
 PROJECT_ID = google.auth.default()[1]

--- a/src/geebeam/__init__.py
+++ b/src/geebeam/__init__.py
@@ -1,19 +1,18 @@
 """Beam and Earth Engine helpers for running data pipelines"""
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("geebeam")
 except PackageNotFoundError:
     __version__ = "unknown"    
 
-from . import pipeline
-from . import sampler
-from .pipeline import run_pipeline, sample_and_run_pipeline, grid_and_run_pipeline
+from . import pipeline, sampler
+from .pipeline import grid_and_run_pipeline, run_pipeline, sample_and_run_pipeline
 
 __all__ = [
+    "grid_and_run_pipeline",
     "pipeline",
-    "sampler",
     "run_pipeline",
     "sample_and_run_pipeline",
-    "grid_and_run_pipeline"
+    "sampler"
 ]

--- a/src/geebeam/_ee_utils.py
+++ b/src/geebeam/_ee_utils.py
@@ -9,6 +9,7 @@ from collections import Counter
 import ee
 import numpy as np
 
+
 def _deserialize(obj_json):
     """Deserialize Earth Engine JSON DAG"""
     return ee.deserializer.fromJSON(obj_json)

--- a/src/geebeam/_tf_utils.py
+++ b/src/geebeam/_tf_utils.py
@@ -1,10 +1,11 @@
 """Helpers for tensorflow"""
 
-import tensorflow as tf
 import apache_beam as beam
 import numpy as np
+import tensorflow as tf
 
 from geebeam import _transforms
+
 
 def _bytes_feature(value):
     """Returns a bytes_list from a string / byte."""

--- a/src/geebeam/_tfds_writer.py
+++ b/src/geebeam/_tfds_writer.py
@@ -1,11 +1,12 @@
 """Pipeline for tensorflow-dataset custom dataset"""
 
-import tensorflow_datasets as tfds
-import tensorflow as tf
-from apache_beam.options.pipeline_options import PipelineOptions
 import numpy as np
+import tensorflow as tf
+import tensorflow_datasets as tfds
+from apache_beam.options.pipeline_options import PipelineOptions
 
 from geebeam import _transforms
+
 
 class _GeebeamBuilderConfig(tfds.core.BuilderConfig):
     """Configuration object for builder."""

--- a/src/geebeam/_tfrecord_writer.py
+++ b/src/geebeam/_tfrecord_writer.py
@@ -1,10 +1,12 @@
 """Pipeline for writing to raw tfrecords (with statistics and schema sidecar files)"""
 
 import os
+
 import apache_beam as beam
 from apache_beam.options.pipeline_options import PipelineOptions
 
-from geebeam import _transforms, _tf_utils
+from geebeam import _tf_utils, _transforms
+
 
 def run_tfrecord_export(
     input_records: list[dict],

--- a/src/geebeam/_tiff_writer.py
+++ b/src/geebeam/_tiff_writer.py
@@ -13,6 +13,8 @@ from rasterio.transform import Affine
 
 from geebeam import _transforms
 
+logger = logging.getLogger(__name__)
+
 
 def _build_tiff_name(id, min_digits=5):
     return f"{str(id).zfill(min_digits)}.tif"
@@ -30,8 +32,8 @@ class WriteTiff(beam.DoFn):
         if not FileSystems.exists(self.output_path):
             try:
                 FileSystems.mkdirs(self.output_path)
-            except Exception as e:
-                logging.warning(f"Error creating directory {self.output_path}: {e}")
+            except OSError as e:
+                logger.warning(f"Output dir already exists {self.output_path}: {e}")
 
     def process(self, element):
         metadata = element['metadata']

--- a/src/geebeam/_tiff_writer.py
+++ b/src/geebeam/_tiff_writer.py
@@ -75,9 +75,9 @@ class WriteTiff(beam.DoFn):
                     dst.set_band_description(i, band_name)
             
             # Upload the temporary file to the final destination
-            with FileSystems.create(tiff_path) as dest:
-                with open(tmp.name, 'rb') as src:
-                    dest.write(src.read())
+            with (FileSystems.create(tiff_path) as dest,
+                  open(tmp.name, 'rb') as src):
+                dest.write(src.read())
 
 
 class ProcessMetadataToParquet(beam.DoFn):

--- a/src/geebeam/_tiff_writer.py
+++ b/src/geebeam/_tiff_writer.py
@@ -1,16 +1,18 @@
 """Pipeline for writing image chips as Cloud-Optimized GeoTIFFs and metadata as Parquet."""
 
+import logging
 import os
 import tempfile
-import logging
+
 import apache_beam as beam
-from apache_beam.options.pipeline_options import PipelineOptions
-from apache_beam.io.filesystems import FileSystems
-import rasterio
-from rasterio.transform import Affine
 import pyarrow as pa
+import rasterio
+from apache_beam.io.filesystems import FileSystems
+from apache_beam.options.pipeline_options import PipelineOptions
+from rasterio.transform import Affine
 
 from geebeam import _transforms
+
 
 def _build_tiff_name(id, min_digits=5):
     return f"{str(id).zfill(min_digits)}.tif"

--- a/src/geebeam/_transforms.py
+++ b/src/geebeam/_transforms.py
@@ -1,7 +1,9 @@
 """Beam _transforms and related utilities"""
 
+import functools
 import json
 import logging
+import operator
 import os
 import time
 
@@ -12,6 +14,7 @@ from apache_beam.io.gcp.gcsio import GcsIO
 
 from geebeam import _ee_utils
 
+logger = logging.getLogger(__name__)
 
 def _write_json_to_local(json_string, local_path):
     data = json_string.encode('utf-8')
@@ -65,7 +68,7 @@ def _split_dataset(element, n_partitions) -> int:
 def join_structured_arrays(array_list):
     """Join structured array along features axis"""
     template = array_list[0]
-    new_dtype = sum([a.dtype.descr for a in array_list], [])
+    new_dtype = functools.reduce(operator.iadd, [a.dtype.descr for a in array_list], [])
     merged = np.empty(template.shape, dtype=new_dtype)
     for a in array_list:
         for feat in a.dtype.names:
@@ -103,7 +106,7 @@ class EEComputePatch(beam.DoFn):
         self.initialized = False
 
     def _initialize_ee(self):
-        logging.info(f"Initializing Earth Engine for project: {self.config['project_id']}")
+        logger.info(f"Initializing Earth Engine for project: {self.config['project_id']}")
         ee.Initialize(project=self.config['project_id'],
                       opt_url='https://earthengine-highvolume.googleapis.com')
         self.initialized = True
@@ -126,7 +129,7 @@ class EEComputePatch(beam.DoFn):
 
         out_dict = {'metadata': dict(point)}
         out_dict['array'] = _join_struct_arrays_to_dict(out_ars)
-        logging.info(
+        logger.info(
             f"EE loaded, {point['id']}, took {time.time() - t0:.1f}s"
         )
         yield out_dict

--- a/src/geebeam/_transforms.py
+++ b/src/geebeam/_transforms.py
@@ -1,16 +1,17 @@
 """Beam _transforms and related utilities"""
 
-import logging
-import time
 import json
+import logging
 import os
+import time
 
-import numpy as np
-from apache_beam.io.gcp.gcsio import GcsIO
 import apache_beam as beam
 import ee
+import numpy as np
+from apache_beam.io.gcp.gcsio import GcsIO
 
 from geebeam import _ee_utils
+
 
 def _write_json_to_local(json_string, local_path):
     data = json_string.encode('utf-8')

--- a/src/geebeam/_wds_writer.py
+++ b/src/geebeam/_wds_writer.py
@@ -1,15 +1,17 @@
 """Pipeline for writing to WebDataset format (.tar files containing .tif and .json)."""
 
-import os
 import json
-import webdataset as wds
-import apache_beam as beam
-from apache_beam.options.pipeline_options import PipelineOptions
-from rasterio.transform import Affine
-from rasterio.io import MemoryFile
+import os
 import uuid
 
+import apache_beam as beam
+import webdataset as wds
+from apache_beam.options.pipeline_options import PipelineOptions
+from rasterio.io import MemoryFile
+from rasterio.transform import Affine
+
 from geebeam import _transforms
+
 
 def _create_tiff_bytes(array_dict, metadata, crs, scale_x, scale_y):
     """Create TIFF bytes from array dict and metadata."""

--- a/src/geebeam/pipeline.py
+++ b/src/geebeam/pipeline.py
@@ -56,12 +56,12 @@ def _build_md_feature_dict(record, extra_metadata):
             md_feature_dict[key] = md_type
     return md_feature_dict
 
-def _prepare_run_metadata(config, transform=None):
+def _prepare_run_metadata(config, align_transform=None):
     ee.Initialize(project=config['project_id'])
 
-    if transform is not None:
+    if align_transform is not None:
         # Pixel size comes from the alignment transform (overrides config['scale'])
-        _, _, scale_x, scale_y = sampler._parse_transform(transform)
+        _, _, scale_x, scale_y = sampler._parse_transform(align_transform)
         return scale_x, scale_y
 
     proj = ee.Projection(config['crs']).atScale(config['scale'])
@@ -74,10 +74,10 @@ def _prepare_run_metadata(config, transform=None):
 
 
 def _apply_position_offset(input_records, position, patch_size, scale_x, scale_y,
-                           transform=None):
+                           align_transform=None):
     """Add x_topleft/y_topleft to each record; original x/y is preserved.
 
-    If transform (a rasterio Affine or array-like with length 6 in the
+    If align_transform (a rasterio Affine or array-like with length 6 in the
     target crs) is provided, each patch's top-left corner is snapped onto that
     transform's pixel grid so the extracted patch aligns exactly.
     """
@@ -99,8 +99,8 @@ def _apply_position_offset(input_records, position, patch_size, scale_x, scale_y
     else:
         raise ValueError(f"Invalid position '{position}'. Must be one of: {sorted(_valid_positions)}")
     records = [{**r, 'x_topleft': r['x'] + dx, 'y_topleft': r['y'] + dy} for r in input_records]
-    if transform is not None:
-        x0, y0, sx, sy = sampler._parse_transform(transform)
+    if align_transform is not None:
+        x0, y0, sx, sy = sampler._parse_transform(align_transform)
         for r in records:
             r['x_topleft'], r['y_topleft'] = sampler._snap_to_grid(
                 r['x_topleft'], r['y_topleft'], x0, y0, sx, sy)
@@ -114,7 +114,7 @@ def run_pipeline(
         patch_size: int,
         scale: float | None = None,
         crs: str = 'EPSG:4326',
-        transform: Affine | tuple[float] | list[float] | None = None,
+        align_transform: Affine | tuple[float] | list[float] | None = None,
         output_type: str = 'tiff',
         split_processing: bool = False,
         extra_metadata: dict = {},
@@ -132,10 +132,10 @@ def run_pipeline(
         output_path: The path where output will be saved.
         project: The Google Cloud project ID.
         patch_size: The size of the patches to be processed.
-        scale: Export resolution in meters. Required unless ``transform`` is provided
+        scale: Export resolution in meters. Required unless ``align_transform`` is provided
             (in which case pixel size comes from the transform and ``scale`` is ignored).
         crs: The coordinate reference system. Defaults to 'EPSG:4326'.
-        transform: Optional full geospatial transform (a rasterio ``Affine`` or a
+        align_transform: Optional full geospatial transform (a rasterio ``Affine`` or a
             list/tuple (length 6) ``(a, b, c, d, e, f)`` in ``crs`` units) to align patches
             to. When provided, the pixel size is taken from the transform and ``scale`` is
             ignored (a warning is emitted), and each patch's top-left corner is snapped onto
@@ -174,14 +174,14 @@ def run_pipeline(
         )
         image_list = [image_list]
 
-    if scale is None and transform is None:
+    if scale is None and align_transform is None:
         raise ValueError(
-            'Provide `scale` (export resolution in meters) or `transform`; '
+            'Provide `scale` (export resolution in meters) or `align_transform`; '
             'pixel size is derived from one of them.'
         )
-    if transform is not None and scale is not None:
+    if align_transform is not None and scale is not None:
         warnings.warn(
-            'Both transform and scale are set; the `scale` argument is ignored. '
+            'Both align_transform and scale are set; the `scale` argument is ignored. '
             'Pixel size is taken from the transform (in crs units) instead.',
             UserWarning,
             stacklevel=2
@@ -220,11 +220,11 @@ def run_pipeline(
     input_records, splits = sampler._process_sampling_points(sampling_points, target_crs=config['crs'])
 
     # Pre-run info:
-    scale_x, scale_y = _prepare_run_metadata(config, transform)
+    scale_x, scale_y = _prepare_run_metadata(config, align_transform)
 
     # Offset sampling location (x, y) -> (x_topleft, y_topleft) based on position arg
     input_records = _apply_position_offset(input_records, position, patch_size, scale_x, scale_y,
-                                           transform=transform)
+                                           align_transform=align_transform)
 
     # Get types of extra non-image data in extra_metadata or input_records
     md_feature_dict = _build_md_feature_dict(input_records[0], extra_metadata)
@@ -338,7 +338,7 @@ def sample_and_run_pipeline(
         crs: str = 'EPSG:4326',
         validation_ratio: float = 0,
         random_seed: int = 0,
-        transform: Affine | tuple[float] | list[float] | None = None,
+        align_transform: Affine | tuple[float] | list[float] | None = None,
         **kwargs
         ) -> None:
     """Sample random points and then run a Beam pipeline to download image chips from Earth Engine.
@@ -350,12 +350,12 @@ def sample_and_run_pipeline(
         output_path: The path where output will be saved.
         project: The Google Cloud project ID.
         patch_size: The size of the patches to be processed.
-        scale: Export resolution in meters. Required unless ``transform`` is provided.
+        scale: Export resolution in meters. Required unless ``align_transform`` is provided.
         validation_ratio: Fraction of points to mark as validation.
         random_seed: Seed for random sampling
         split_processing: Flag to indicate if processing should be split. Defaults to False.
         crs: The coordinate reference system for sampling. Defaults to 'EPSG:4326'.
-        transform: Optional full geospatial transform (rasterio ``Affine`` or list-like length 6
+        align_transform: Optional full geospatial align_transform (rasterio ``Affine`` or list-like length 6
             ``crs`` units) to align samples to. See :meth:`pipeline.run_pipeline`. Defaults to None.
         **kwargs: Additional keyword arguments are documented in :meth:`pipeline.run_pipeline`.
 
@@ -366,7 +366,7 @@ def sample_and_run_pipeline(
         n_sample=n_sample,
         random_seed=random_seed,
         crs=crs,
-        transform=transform,
+        align_transform=align_transform,
     )
 
     if validation_ratio > 0:
@@ -383,7 +383,7 @@ def sample_and_run_pipeline(
         project=project,
         patch_size=patch_size,
         scale=scale,
-        transform=transform,
+        align_transform=align_transform,
         **kwargs)
 
 def grid_and_run_pipeline(
@@ -394,7 +394,7 @@ def grid_and_run_pipeline(
         patch_size: int,
         stride: int,
         scale: float | None = None,
-        transform: Affine | tuple[float] | list[float] | None = None,
+        align_transform: Affine | tuple[float] | list[float] | None = None,
         crs: str = 'EPSG:4326',
         buffer_distance: float = 0,
         validation_ratio: float = 0,
@@ -412,10 +412,10 @@ def grid_and_run_pipeline(
         stride: Number of pixels between consecutive samples. If want full coverage without
             overlaps, stride should be equal to patch_size. If less than patch_size, will
             generate overlaps. If greater, will be gaps between sampled patches.
-        scale: Export resolution in meters. Required unless ``transform`` is provided.
-        transform: Optional full geospatial transform (rasterio ``Affine`` or list-like
+        scale: Export resolution in meters. Required unless ``align_transform`` is provided.
+        align_transform: Optional full geospatial align_transform (rasterio ``Affine`` or list-like
             (length 6) in ``crs`` units) to align samples to. When provided, the grid uses
-            the transform's pixel size and origin. See :meth:`pipeline.run_pipeline`.
+            the align_transform's pixel size and origin. See :meth:`pipeline.run_pipeline`.
             Defaults to None.
         crs: The coordinate reference system for sampling. Defaults to 'EPSG:4326'.
         buffer_distance: Distance (in meters) to buffer sampling_region by before gridding.
@@ -431,7 +431,7 @@ def grid_and_run_pipeline(
         stride=stride,
         scale=scale,
         buffer_distance=buffer_distance,
-        transform=transform,
+        align_transform=align_transform,
     )
 
     if validation_ratio > 0:
@@ -448,5 +448,5 @@ def grid_and_run_pipeline(
         project=project,
         patch_size=patch_size,
         scale=scale,
-        transform=transform,
+        align_transform=align_transform,
         **kwargs)

--- a/src/geebeam/pipeline.py
+++ b/src/geebeam/pipeline.py
@@ -392,7 +392,7 @@ def grid_and_run_pipeline(
         output_path: str,
         project: str,
         patch_size: int,
-        stride: int,
+        stride: int | None = None,
         scale: float | None = None,
         align_transform: Affine | tuple[float] | list[float] | None = None,
         crs: str = 'EPSG:4326',
@@ -411,7 +411,8 @@ def grid_and_run_pipeline(
         patch_size: The size of the patches to be processed.
         stride: Number of pixels between consecutive samples. If want full coverage without
             overlaps, stride should be equal to patch_size. If less than patch_size, will
-            generate overlaps. If greater, will be gaps between sampled patches.
+            generate overlaps. If greater, will be gaps between sampled patches. If None,
+            defaults to patch_size. Default is None.
         scale: Export resolution in meters. Required unless ``align_transform`` is provided.
         align_transform: Optional full geospatial align_transform (rasterio ``Affine`` or list-like
             (length 6) in ``crs`` units) to align samples to. When provided, the grid uses
@@ -424,6 +425,9 @@ def grid_and_run_pipeline(
         random_seed: Seed for random sampling
         **kwargs: Additional keyword arguments are documented in :meth:`pipeline.run_pipeline`.
     """
+
+    if stride is None:
+        stride = patch_size
 
     sample_points = sampler.sample_region_grid(
         roi=sampling_region,

--- a/src/geebeam/pipeline.py
+++ b/src/geebeam/pipeline.py
@@ -6,6 +6,7 @@ import geopandas as gpd
 import pandas as pd
 from apache_beam.options.pipeline_options import PipelineOptions
 import numpy as np
+from rasterio import Affine
 
 from geebeam import _ee_utils, sampler, _transforms
 
@@ -55,8 +56,13 @@ def _build_md_feature_dict(record, extra_metadata):
             md_feature_dict[key] = md_type
     return md_feature_dict
 
-def _prepare_run_metadata(config):
+def _prepare_run_metadata(config, transform=None):
     ee.Initialize(project=config['project_id'])
+
+    if transform is not None:
+        # Pixel size comes from the alignment transform (overrides config['scale'])
+        _, _, scale_x, scale_y = sampler._parse_transform(transform)
+        return scale_x, scale_y
 
     proj = ee.Projection(config['crs']).atScale(config['scale'])
     proj_dict = proj.getInfo()
@@ -67,8 +73,14 @@ def _prepare_run_metadata(config):
     return scale_x, scale_y
 
 
-def _apply_position_offset(input_records, position, patch_size, scale_x, scale_y):
-    """Add x_topleft/y_topleft to each record; original x/y (the sampling location) is preserved."""
+def _apply_position_offset(input_records, position, patch_size, scale_x, scale_y,
+                           transform=None):
+    """Add x_topleft/y_topleft to each record; original x/y is preserved.
+
+    If transform (a rasterio Affine or array-like with length 6 in the
+    target crs) is provided, each patch's top-left corner is snapped onto that
+    transform's pixel grid so the extracted patch aligns exactly.
+    """
     _valid_positions = {'center', 'top-left', 'top-right', 'bottom-left', 'bottom-right'}
     if position == 'top-left':
         dx, dy = 0, 0
@@ -86,23 +98,30 @@ def _apply_position_offset(input_records, position, patch_size, scale_x, scale_y
         dy = -patch_size * scale_y
     else:
         raise ValueError(f"Invalid position '{position}'. Must be one of: {sorted(_valid_positions)}")
-    return [{**r, 'x_topleft': r['x'] + dx, 'y_topleft': r['y'] + dy} for r in input_records]
+    records = [{**r, 'x_topleft': r['x'] + dx, 'y_topleft': r['y'] + dy} for r in input_records]
+    if transform is not None:
+        x0, y0, sx, sy = sampler._parse_transform(transform)
+        for r in records:
+            r['x_topleft'], r['y_topleft'] = sampler._snap_to_grid(
+                r['x_topleft'], r['y_topleft'], x0, y0, sx, sy)
+    return records
 
 def run_pipeline(
         image_list: list[ee.Image],
+        sampling_points: pd.DataFrame | gpd.GeoDataFrame | ee.FeatureCollection,
         output_path: str,
         project: str,
         patch_size: int,
-        scale: float,
-        sampling_points: pd.DataFrame | gpd.GeoDataFrame | ee.FeatureCollection,
-        output_type: str = 'tiff',
+        scale: float | None = None,
         crs: str = 'EPSG:4326',
+        transform: Affine | tuple[float] | list[float] | None = None,
+        output_type: str = 'tiff',
         split_processing: bool = False,
         extra_metadata: dict = {},
         beam_options: dict[str] | list[str] | None = None,
         dataset_version: str = '1.0.0',
         dataset_name: str = 'geebeam_dataset',
-        position: str = 'center'
+        position: str = 'center',
         ) -> None:
     """Run a Beam pipeline to download image chips from Earth Engine.
 
@@ -111,13 +130,21 @@ def run_pipeline(
         sampling_points: Locations to sample from. The position of each point relative
             to the patch is controlled by the ``position`` argument.
         output_path: The path where output will be saved.
+        project: The Google Cloud project ID.
+        patch_size: The size of the patches to be processed.
+        scale: Export resolution in meters. Required unless ``transform`` is provided
+            (in which case pixel size comes from the transform and ``scale`` is ignored).
+        crs: The coordinate reference system. Defaults to 'EPSG:4326'.
+        transform: Optional full geospatial transform (a rasterio ``Affine`` or a
+            list/tuple (length 6) ``(a, b, c, d, e, f)`` in ``crs`` units) to align patches
+            to. When provided, the pixel size is taken from the transform and ``scale`` is
+            ignored (a warning is emitted), and each patch's top-left corner is snapped onto
+            the transform's pixel grid, so the extracted patch aligns exactly to that grid 
+            with no resampling. Rotation/shear (non-zero ``b``/``d``) is not supported.
+            Defaults to None.
         output_type: 'tiff' (tiffs with parquet for metadata),
             'webdataset' (tiffs with jsons, in sharded tars),
             'tfrecord' (raw tfrecords), or 'tfds' (tensorflow-dataset).
-        project: The Google Cloud project ID.
-        patch_size: The size of the patches to be processed.
-        scale: The scale factor for image processing.
-        crs: The coordinate reference system. Defaults to 'EPSG:4326'.
         split_processing: Flag to indicate if processing should be split. Defaults to False.
         extra_metadata: Additional metadata to include. Defaults to an empty dictionary.
         beam_options_dict: Options for the Beam pipeline. Defaults to an empty dictionary.
@@ -146,6 +173,19 @@ def run_pipeline(
             stacklevel=2
         )
         image_list = [image_list]
+
+    if scale is None and transform is None:
+        raise ValueError(
+            'Provide `scale` (export resolution in meters) or `transform`; '
+            'pixel size is derived from one of them.'
+        )
+    if transform is not None and scale is not None:
+        warnings.warn(
+            'Both transform and scale are set; the `scale` argument is ignored. '
+            'Pixel size is taken from the transform (in crs units) instead.',
+            UserWarning,
+            stacklevel=2
+        )
 
     # Set up configuration dict to pass along
     config = {
@@ -180,10 +220,11 @@ def run_pipeline(
     input_records, splits = sampler._process_sampling_points(sampling_points, target_crs=config['crs'])
 
     # Pre-run info:
-    scale_x, scale_y = _prepare_run_metadata(config)
+    scale_x, scale_y = _prepare_run_metadata(config, transform)
 
     # Offset sampling location (x, y) -> (x_topleft, y_topleft) based on position arg
-    input_records = _apply_position_offset(input_records, position, patch_size, scale_x, scale_y)
+    input_records = _apply_position_offset(input_records, position, patch_size, scale_x, scale_y,
+                                           transform=transform)
 
     # Get types of extra non-image data in extra_metadata or input_records
     md_feature_dict = _build_md_feature_dict(input_records[0], extra_metadata)
@@ -293,10 +334,11 @@ def sample_and_run_pipeline(
         output_path: str,
         project: str,
         patch_size: int,
-        scale: float,
+        scale: float | None = None,
         crs: str = 'EPSG:4326',
         validation_ratio: float = 0,
         random_seed: int = 0,
+        transform: Affine | tuple[float] | list[float] | None = None,
         **kwargs
         ) -> None:
     """Sample random points and then run a Beam pipeline to download image chips from Earth Engine.
@@ -308,11 +350,13 @@ def sample_and_run_pipeline(
         output_path: The path where output will be saved.
         project: The Google Cloud project ID.
         patch_size: The size of the patches to be processed.
-        scale: The scale factor for image processing.
+        scale: Export resolution in meters. Required unless ``transform`` is provided.
         validation_ratio: Fraction of points to mark as validation.
         random_seed: Seed for random sampling
         split_processing: Flag to indicate if processing should be split. Defaults to False.
         crs: The coordinate reference system for sampling. Defaults to 'EPSG:4326'.
+        transform: Optional full geospatial transform (rasterio ``Affine`` or list-like length 6
+            ``crs`` units) to align samples to. See :meth:`pipeline.run_pipeline`. Defaults to None.
         **kwargs: Additional keyword arguments are documented in :meth:`pipeline.run_pipeline`.
 
     """
@@ -322,6 +366,7 @@ def sample_and_run_pipeline(
         n_sample=n_sample,
         random_seed=random_seed,
         crs=crs,
+        transform=transform,
     )
 
     if validation_ratio > 0:
@@ -338,6 +383,7 @@ def sample_and_run_pipeline(
         project=project,
         patch_size=patch_size,
         scale=scale,
+        transform=transform,
         **kwargs)
 
 def grid_and_run_pipeline(
@@ -346,8 +392,9 @@ def grid_and_run_pipeline(
         output_path: str,
         project: str,
         patch_size: int,
-        scale: float,
         stride: int,
+        scale: float | None = None,
+        transform: Affine | tuple[float] | list[float] | None = None,
         crs: str = 'EPSG:4326',
         buffer_distance: float = 0,
         validation_ratio: float = 0,
@@ -362,10 +409,14 @@ def grid_and_run_pipeline(
         output_path: The path where output will be saved.
         project: The Google Cloud project ID.
         patch_size: The size of the patches to be processed.
-        scale: The scale factor for image processing.
-        stride: Number of pixels between consecutive samples. If want full coverage without overlaps,
-            stride should be equal to patch_size. If less than patch_size, will generate overlaps.
-            If greater, will be gaps between sampled patches.
+        stride: Number of pixels between consecutive samples. If want full coverage without
+            overlaps, stride should be equal to patch_size. If less than patch_size, will
+            generate overlaps. If greater, will be gaps between sampled patches.
+        scale: Export resolution in meters. Required unless ``transform`` is provided.
+        transform: Optional full geospatial transform (rasterio ``Affine`` or list-like
+            (length 6) in ``crs`` units) to align samples to. When provided, the grid uses
+            the transform's pixel size and origin. See :meth:`pipeline.run_pipeline`.
+            Defaults to None.
         crs: The coordinate reference system for sampling. Defaults to 'EPSG:4326'.
         buffer_distance: Distance (in meters) to buffer sampling_region by before gridding.
             Can be used to ensure complete coverage at edges of sampling_region.
@@ -376,10 +427,11 @@ def grid_and_run_pipeline(
 
     sample_points = sampler.sample_region_grid(
         roi=sampling_region,
-        crs='EPSG:4326',
+        crs=crs,
         stride=stride,
         scale=scale,
         buffer_distance=buffer_distance,
+        transform=transform,
     )
 
     if validation_ratio > 0:
@@ -396,4 +448,5 @@ def grid_and_run_pipeline(
         project=project,
         patch_size=patch_size,
         scale=scale,
+        transform=transform,
         **kwargs)

--- a/src/geebeam/pipeline.py
+++ b/src/geebeam/pipeline.py
@@ -1,14 +1,15 @@
 """Prepare and run Beam pipeline to download image 'chips' from Earth Engine"""
 
 import warnings
+
 import ee
 import geopandas as gpd
+import numpy as np
 import pandas as pd
 from apache_beam.options.pipeline_options import PipelineOptions
-import numpy as np
 from rasterio import Affine
 
-from geebeam import _ee_utils, sampler, _transforms
+from geebeam import _ee_utils, _transforms, sampler
 
 
 def _check_if_localrunner(pipeline_options):

--- a/src/geebeam/pipeline.py
+++ b/src/geebeam/pipeline.py
@@ -15,22 +15,19 @@ from geebeam import _ee_utils, _transforms, sampler
 def _check_if_localrunner(pipeline_options):
     """Fixes gRPC timeout issue for local runners."""
     runner = pipeline_options.get_all_options()['runner']
-    if runner is None or runner in ['DirectRunner', 'PrismRunner']:
-        return True
-    else:
-        return False
+    return runner is None or runner in ['DirectRunner', 'PrismRunner']
 
 def _type_inference(val):
     if isinstance(val, int):
         return 'int'
     elif isinstance(val, float):
         return 'float'
-    elif isinstance(val, list) or isinstance(val, np.ndarray):
+    elif isinstance(val, (list, np.ndarray)):
         return {'arraylike': np.array(val).shape}
     elif isinstance(val, str):
         return 'str'
     else:
-        raise ValueError
+        raise TypeError
 
 def _build_md_feature_dict(record, extra_metadata):
     md_feature_dict = {
@@ -40,7 +37,7 @@ def _build_md_feature_dict(record, extra_metadata):
         'split':'str'
     }
     if extra_metadata is not None:
-        for key in extra_metadata.keys():
+        for key in extra_metadata:
             # Basic type inference for extra metadata
             try:
                 md_type = _type_inference(extra_metadata[key])
@@ -48,7 +45,7 @@ def _build_md_feature_dict(record, extra_metadata):
                 raise ValueError(f'Could not determine data type of extra_metadata feature {key}')
             md_feature_dict[key] = md_type
 
-    for key in record.keys():
+    for key in record:
         if key not in ['id','x','y','split']:
             try:
                 md_type = _type_inference(record[key])
@@ -118,7 +115,7 @@ def run_pipeline(
         align_transform: Affine | tuple[float] | list[float] | None = None,
         output_type: str = 'tiff',
         split_processing: bool = False,
-        extra_metadata: dict = {},
+        extra_metadata: dict | None = None,
         beam_options: dict[str] | list[str] | None = None,
         dataset_version: str = '1.0.0',
         dataset_name: str = 'geebeam_dataset',
@@ -159,10 +156,10 @@ def run_pipeline(
     """
     import logging
 
-    logging.getLogger().setLevel(logging.INFO)
+    logger = logging.getLogger(__name__).setLevel(logging.INFO)
 
     if isinstance(image_list, ee.ImageCollection):
-        raise ValueError(
+        raise TypeError(
             'image_list must be a list of ee.Image objects, not an ee.ImageCollection. '
             'Convert first with image_list = [collection.mosaic()] or similar.'
         )
@@ -187,6 +184,9 @@ def run_pipeline(
             UserWarning,
             stacklevel=2
         )
+
+    if not extra_metadata:
+        extra_metadata = {}
 
     # Set up configuration dict to pass along
     config = {
@@ -233,8 +233,8 @@ def run_pipeline(
     # Check if a local runner. If so, add longer job timeout to fix grpcio timeout issue
     is_local = _check_if_localrunner(pipeline_options)
     if is_local:
-        logging.warning('Running on local runner. Setting beam job_server_timeout'
-                        ' to 9999999 seconds to avoid grpcio timeout errors.')
+        logger.warning('Running on local runner. Setting beam job_server_timeout'
+                       ' to 9999999 seconds to avoid grpcio timeout errors.')
         pipeline_options_dict = pipeline_options.get_all_options(drop_default=True)
         pipeline_options_dict['job_server_timeout'] = 9999999
         pipeline_options = PipelineOptions.from_dictionary(pipeline_options_dict)

--- a/src/geebeam/sampler.py
+++ b/src/geebeam/sampler.py
@@ -8,6 +8,7 @@ import pandas as pd
 import geopandas as gpd
 import shapely
 import ee
+from rasterio import Affine
 
 
 def _get_crs_scale(
@@ -17,6 +18,30 @@ def _get_crs_scale(
     """Find equivalent scale in m for crs"""
     transform = ee.Projection(crs=crs).atScale(scale_m).getInfo()['transform']
     return transform[0]
+
+def _parse_transform(transform):
+    """Return (x0, y0, scale_x, scale_y) from a rasterio Affine or 6-tuple.
+
+    The transform is given in Affine order (a, b, c, d, e, f) =
+    (scale_x, shear_x, translate_x, shear_y, scale_y, translate_y). scale_x/scale_y
+    are returned as positive pixel-size magnitudes, matching the existing pipeline
+    convention (scale_y = -transform[4]). Rotation/shear is not supported.
+    """
+    a, b, c, d, e, f = tuple(transform)[:6]
+    if b != 0 or d != 0:
+        raise ValueError('transform must have zero shear/rotation (b and d must be 0).')
+    return c, f, abs(a), abs(e)
+
+def _snap_to_grid(x, y, x0, y0, scale_x, scale_y):
+    """Snap coordinate(s) to the nearest node of the reference grid.
+
+    Works for both scalar and array inputs. Returns Python floats for scalar input.
+    """
+    xs = x0 + np.round((np.asarray(x, dtype=float) - x0) / scale_x) * scale_x
+    ys = y0 + np.round((np.asarray(y, dtype=float) - y0) / scale_y) * scale_y
+    if np.ndim(x) == 0:
+        return float(xs), float(ys)
+    return xs, ys
 
 def _get_roi(
     sampling_region: str | ee.Geometry | gpd.GeoDataFrame,
@@ -94,9 +119,16 @@ def sample_region_random(
         crs: str,
         n_sample: int,
         random_seed: int = 0,
-        buffer_distance: float = 0
+        buffer_distance: float = 0,
+        transform: Affine | tuple[float] | list[float] | None = None,
         ) -> gpd.GeoDataFrame:
-    """Get random points within region of interest."""
+    """Get random points within region of interest.
+
+    If transform (a rasterio Affine or list/tuple length 6 in the target crs) is provided,
+    the sampled points are snapped onto that transform's pixel grid. Note that snapping to a grid
+    that is coarse relative to the sampling density can collapse distinct random points
+    onto the same location; a warning is emitted if this happens.
+    """
     rng = np.random.default_rng(random_seed)
     roi = _get_roi(roi, crs)
     if buffer_distance != 0:
@@ -105,6 +137,22 @@ def sample_region_random(
 
     sampled_points = gpd.GeoDataFrame(geometry=roi.sample_points(n_sample, rng=rng).geometry.explode(),
                                       crs=crs)
+    if transform is not None:
+        x0, y0, sx, sy = _parse_transform(transform)
+        xs, ys = _snap_to_grid(sampled_points.geometry.x.values,
+                               sampled_points.geometry.y.values, x0, y0, sx, sy)
+        n_unique = np.unique(np.column_stack([xs, ys]), axis=0).shape[0]
+        n_collisions = len(xs) - n_unique
+        if n_collisions > 0:
+            warnings.warn(
+                f'transform snapped {n_collisions} of {len(xs)} random point(s) onto '
+                'locations already occupied by another point (duplicate locations). The '
+                'alignment grid is coarse relative to the sampling density; use a finer '
+                'transform or fewer points to avoid duplicates.',
+                UserWarning,
+                stacklevel=2
+            )
+        sampled_points = gpd.GeoDataFrame(geometry=gpd.points_from_xy(xs, ys), crs=crs)
     sampled_points.index = np.arange(sampled_points.shape[0])
     return sampled_points
 
@@ -112,18 +160,40 @@ def sample_region_grid(
         roi: gpd.GeoDataFrame,
         crs: str,
         stride: int,
-        scale: float,
+        scale: float | None = None,
+        transform: Affine | tuple[float] | list[float] | None = None,
         buffer_distance: float = 0,
         ) -> gpd.GeoDataFrame:
-    """Get a regular grid of points covering region of interest"""
+    """Get a regular grid of points covering region of interest.
+
+    ``scale`` (grid spacing in meters, as scale*stride) is required unless transform
+    is provided. If transform (a rasterio Affine or 6-tuple in the target crs) is
+    provided, the grid uses that transform's pixel size (``scale`` is ignored) and its origin
+    is anchored to the transform, so every location falls on that transform's pixel grid.
+    """
+    if transform is None and scale is None:
+        raise ValueError('`scale` is required unless transform is provided.')
     roi = _get_roi(roi, crs)
-    scale_proj = _get_crs_scale(roi.crs.to_string(), scale)
-    if buffer_distance != 0:
-        scale_proj_1m = scale_proj/scale
-        roi = roi.dissolve().buffer(scale_proj_1m*buffer_distance)
-    xmin, ymin, xmax, ymax = roi.total_bounds
-    x_locs = np.arange(xmin, xmax+scale_proj*stride, scale_proj*stride)
-    y_locs = np.arange(ymin, ymax+scale_proj*stride, scale_proj*stride)
+    if transform is not None:
+        x0, y0, sx, sy = _parse_transform(transform)
+        if buffer_distance != 0:
+            scale_proj_1m = _get_crs_scale(roi.crs.to_string(), 1)
+            roi = roi.dissolve().buffer(scale_proj_1m*buffer_distance)
+        xmin, ymin, xmax, ymax = roi.total_bounds
+        step_x, step_y = sx*stride, sy*stride
+        # Anchor the grid to the reference transform (nodes = origin + whole pixels)
+        x_start = x0 + np.floor((xmin - x0)/sx)*sx
+        y_start = y0 + np.floor((ymin - y0)/sy)*sy
+        x_locs = np.arange(x_start, xmax+step_x, step_x)
+        y_locs = np.arange(y_start, ymax+step_y, step_y)
+    else:
+        scale_proj = _get_crs_scale(roi.crs.to_string(), scale)
+        if buffer_distance != 0:
+            scale_proj_1m = scale_proj/scale
+            roi = roi.dissolve().buffer(scale_proj_1m*buffer_distance)
+        xmin, ymin, xmax, ymax = roi.total_bounds
+        x_locs = np.arange(xmin, xmax+scale_proj*stride, scale_proj*stride)
+        y_locs = np.arange(ymin, ymax+scale_proj*stride, scale_proj*stride)
     meshgrid = np.array(np.meshgrid(x_locs, y_locs)).T.reshape(-1, 2)
     x_all, y_all = meshgrid[:,0],  meshgrid[:,1]
 

--- a/src/geebeam/sampler.py
+++ b/src/geebeam/sampler.py
@@ -60,8 +60,8 @@ def _get_roi(
         elif isinstance(sampling_region, shapely.Geometry):
             roi_df = gpd.GeoDataFrame(geometry=[sampling_region], crs=target_crs)
         else:
-            raise ValueError("'sampling_region' must be one of"
-                                "[str, ee.Geometry, gpd.GeoDataFrame]")
+            raise TypeError("'sampling_region' must be one of"
+                            "[str, ee.Geometry, gpd.GeoDataFrame]")
         source_crs = roi_df.crs.to_string()
         if source_crs != target_crs:
             warnings.warn(f'Converting ROI from crs {source_crs} to target_crs: {target_crs}')
@@ -98,8 +98,8 @@ def _process_sampling_points(
                 }
             ).set_crs(fc_crs)
     else:
-        raise ValueError("'sampling_points' must be one of"
-                         "[pd.DataFrame, gpd.GeoDataFrame, ee.FeatureCollection]")
+        raise TypeError("'sampling_points' must be one of"
+                        "[pd.DataFrame, gpd.GeoDataFrame, ee.FeatureCollection]")
 
     if 'id' not in points_gdf.columns:
         points_gdf['id'] = np.arange(points_gdf.shape[0])

--- a/src/geebeam/sampler.py
+++ b/src/geebeam/sampler.py
@@ -2,6 +2,7 @@
 
 import json
 import warnings
+from functools import partial
 
 import ee
 import geopandas as gpd
@@ -219,6 +220,9 @@ def _assign_splits_pandas(df, split_dict, random_seed=0, shuffle=True):
 
     return df
 
+def _set_split_ee(f, split_name):
+    return ee.Feature(f).set('split', split_name)
+
 def _assign_splits_ee(ee_fc, split_dict, random_seed=0, shuffle=True):
     cur_index = 0
     # Shuffle order
@@ -229,12 +233,10 @@ def _assign_splits_ee(ee_fc, split_dict, random_seed=0, shuffle=True):
     cur_index = 0
 
     for split_name, split_count in split_dict.items():
+        _set_cur_split = partial(_set_split_ee(split_name=split_name))
         fc_slice = ee_fc.toList(count=split_count,
-                               offset=cur_index)
-        def _set_split_ee(f):
-            return ee.Feature(f).set('split', split_name)
-
-        output_features.append(fc_slice.map(_set_split_ee))
+                                offset=cur_index)
+        output_features.append(fc_slice.map(_set_cur_split))
         cur_index += split_count
 
     # Flatten the list of lists back into a single FeatureCollection

--- a/src/geebeam/sampler.py
+++ b/src/geebeam/sampler.py
@@ -120,11 +120,11 @@ def sample_region_random(
         n_sample: int,
         random_seed: int = 0,
         buffer_distance: float = 0,
-        transform: Affine | tuple[float] | list[float] | None = None,
+        align_transform: Affine | tuple[float] | list[float] | None = None,
         ) -> gpd.GeoDataFrame:
     """Get random points within region of interest.
 
-    If transform (a rasterio Affine or list/tuple length 6 in the target crs) is provided,
+    If align_transform (a rasterio Affine or list/tuple length 6 in the target crs) is provided,
     the sampled points are snapped onto that transform's pixel grid. Note that snapping to a grid
     that is coarse relative to the sampling density can collapse distinct random points
     onto the same location; a warning is emitted if this happens.
@@ -137,8 +137,8 @@ def sample_region_random(
 
     sampled_points = gpd.GeoDataFrame(geometry=roi.sample_points(n_sample, rng=rng).geometry.explode(),
                                       crs=crs)
-    if transform is not None:
-        x0, y0, sx, sy = _parse_transform(transform)
+    if align_transform is not None:
+        x0, y0, sx, sy = _parse_transform(align_transform)
         xs, ys = _snap_to_grid(sampled_points.geometry.x.values,
                                sampled_points.geometry.y.values, x0, y0, sx, sy)
         n_unique = np.unique(np.column_stack([xs, ys]), axis=0).shape[0]
@@ -148,7 +148,7 @@ def sample_region_random(
                 f'transform snapped {n_collisions} of {len(xs)} random point(s) onto '
                 'locations already occupied by another point (duplicate locations). The '
                 'alignment grid is coarse relative to the sampling density; use a finer '
-                'transform or fewer points to avoid duplicates.',
+                'align_transform or fewer points to avoid duplicates.',
                 UserWarning,
                 stacklevel=2
             )
@@ -161,27 +161,27 @@ def sample_region_grid(
         crs: str,
         stride: int,
         scale: float | None = None,
-        transform: Affine | tuple[float] | list[float] | None = None,
+        align_transform: Affine | tuple[float] | list[float] | None = None,
         buffer_distance: float = 0,
         ) -> gpd.GeoDataFrame:
     """Get a regular grid of points covering region of interest.
 
-    ``scale`` (grid spacing in meters, as scale*stride) is required unless transform
-    is provided. If transform (a rasterio Affine or 6-tuple in the target crs) is
+    ``scale`` (grid spacing in meters, as scale*stride) is required unless ``align_transform``
+    is provided. If transform (a rasterio Affine or list/tuple in the target crs) is
     provided, the grid uses that transform's pixel size (``scale`` is ignored) and its origin
     is anchored to the transform, so every location falls on that transform's pixel grid.
     """
-    if transform is None and scale is None:
-        raise ValueError('`scale` is required unless transform is provided.')
+    if align_transform is None and scale is None:
+        raise ValueError('`scale` is required unless align_transform is provided.')
     roi = _get_roi(roi, crs)
-    if transform is not None:
-        x0, y0, sx, sy = _parse_transform(transform)
+    if align_transform is not None:
+        x0, y0, sx, sy = _parse_transform(align_transform)
         if buffer_distance != 0:
             scale_proj_1m = _get_crs_scale(roi.crs.to_string(), 1)
             roi = roi.dissolve().buffer(scale_proj_1m*buffer_distance)
         xmin, ymin, xmax, ymax = roi.total_bounds
         step_x, step_y = sx*stride, sy*stride
-        # Anchor the grid to the reference transform (nodes = origin + whole pixels)
+        # Anchor the grid to the reference transform
         x_start = x0 + np.floor((xmin - x0)/sx)*sx
         y_start = y0 + np.floor((ymin - y0)/sy)*sy
         x_locs = np.arange(x_start, xmax+step_x, step_x)

--- a/src/geebeam/sampler.py
+++ b/src/geebeam/sampler.py
@@ -1,13 +1,13 @@
 """Helper for sampling locations across regions of interest"""
 
+import json
 import warnings
 
-import json
+import ee
+import geopandas as gpd
 import numpy as np
 import pandas as pd
-import geopandas as gpd
 import shapely
-import ee
 from rasterio import Affine
 
 

--- a/tests/test_ee_utils.py
+++ b/tests/test_ee_utils.py
@@ -1,16 +1,18 @@
 import io
-import pytest
+from unittest.mock import MagicMock, patch
+
 import numpy as np
-import ee
-from unittest.mock import patch, MagicMock
+import pytest
+
 from geebeam._ee_utils import (
-    get_band_names,
-    build_prepped_image,
     _dedupe_band_names,
-    list_to_im,
+    build_prepped_image,
+    get_band_names,
     get_pixels,
     get_pixels_allbands,
+    list_to_im,
 )
+
 
 def test_get_band_names():
     mock_image1 = MagicMock()

--- a/tests/test_ee_utils.py
+++ b/tests/test_ee_utils.py
@@ -39,7 +39,7 @@ def test_build_prepped_image(mock_ee_list, mock_ee_ic):
     assert band_groups == [['b1', 'b2']]
     assert all_bands == ['b1', 'b2']
 
-    result_im, band_groups, all_bands = build_prepped_image([mock_image1, mock_image2], split_processing=True)
+    _result_im, band_groups, all_bands = build_prepped_image([mock_image1, mock_image2], split_processing=True)
     assert band_groups == [['b1'], ['b2']]
     assert all_bands == ['b1', 'b2']
 
@@ -55,14 +55,14 @@ def test_build_prepped_image_deduplicates(mock_ee_list, mock_ee_ic):
     mock_ee_ic.return_value.toBands.return_value.rename.return_value = mock_prepped_im
 
     with pytest.warns(UserWarning, match='Duplicate band names'):
-        result_im, band_groups, all_bands = build_prepped_image(
+        _result_im, band_groups, all_bands = build_prepped_image(
             [mock_image1, mock_image2], split_processing=False
         )
     assert all_bands == ['b1_0', 'b2', 'b1_1', 'b3']
     assert band_groups == [['b1_0', 'b2', 'b1_1', 'b3']]
 
     with pytest.warns(UserWarning, match='Duplicate band names'):
-        result_im, band_groups, all_bands = build_prepped_image(
+        _result_im, band_groups, all_bands = build_prepped_image(
             [mock_image1, mock_image2], split_processing=True
         )
     assert all_bands == ['b1_0', 'b2', 'b1_1', 'b3']

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,15 +2,16 @@
 
 import glob
 import os
-import pytest
-import numpy as np
-import apache_beam as beam
-from apache_beam.options.pipeline_options import PipelineOptions
 from unittest.mock import patch
 
+import apache_beam as beam
+import numpy as np
+import pytest
+from apache_beam.options.pipeline_options import PipelineOptions
+
+from geebeam._tfrecord_writer import run_tfrecord_export
 from geebeam._tiff_writer import run_tiff_export
 from geebeam._wds_writer import run_webdataset_export
-from geebeam._tfrecord_writer import run_tfrecord_export
 
 
 class _FakeComputePatch(beam.DoFn):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -128,13 +128,13 @@ def test_apply_position_offset_invalid_position():
 @pytest.mark.parametrize('position', ['top-left', 'top-right', 'bottom-left', 'bottom-right', 'center'])
 @pytest.mark.parametrize('patch_size', [4, 5])  # even and odd
 def test_apply_position_offset_align_snaps_topleft(position, patch_size):
-    """With transform, the top-left corner must land exactly on the reference grid,
+    """With align_transform, the top-left corner must land exactly on the reference grid,
     for any position and any (even/odd) patch_size."""
     # origin (0, 0), pixel size 1.0 -> grid nodes are integers
     align = Affine(1.0, 0, 0.0, 0, -1.0, 0.0)
     records = [{'id': 0, 'x': 3.37, 'y': 8.62, 'split': 'full'}]
     result = _apply_position_offset(records, position, patch_size, 1.0, 1.0,
-                                    transform=align)
+                                    align_transform=align)
     x_tl, y_tl = result[0]['x_topleft'], result[0]['y_topleft']
     assert x_tl == round(x_tl)
     assert y_tl == round(y_tl)
@@ -145,11 +145,11 @@ def test_apply_position_offset_align_snaps_topleft(position, patch_size):
 @patch('ee.Initialize')
 @patch('ee.Projection')
 def test_prepare_run_metadata_align_overrides_scale(mock_projection, mock_ee_init):
-    """transform pixel size overrides scale; ee.Projection should not be consulted."""
+    """align_transform pixel size overrides scale; ee.Projection should not be consulted."""
     config = {'project_id': 'test-project', 'crs': 'EPSG:4326', 'scale': 30}
     align = Affine(0.25, 0, 100.0, 0, -0.5, 200.0)
 
-    scale_x, scale_y = _prepare_run_metadata(config, transform=align)
+    scale_x, scale_y = _prepare_run_metadata(config, align_transform=align)
 
     assert scale_x == 0.25
     assert scale_y == 0.5  # abs(-0.5)
@@ -178,7 +178,7 @@ def test_run_pipeline_wraps_single_image(mock_projection, mock_ee_init):
             pass  # pipeline will fail further on; we only care the warning fired
 
 def test_run_pipeline_transform_warns_scale_ignored():
-    """Passing transform should warn that `scale` is ignored."""
+    """Passing align_transform should warn that `scale` is ignored."""
     with pytest.warns(UserWarning, match='`scale` argument is ignored'):
         try:
             run_pipeline(
@@ -188,14 +188,14 @@ def test_run_pipeline_transform_warns_scale_ignored():
                 patch_size=4,
                 scale=30.0,
                 sampling_points=MagicMock(),
-                transform=Affine(0.001, 0, 0, 0, -0.001, 0),
+                align_transform=Affine(0.001, 0, 0, 0, -0.001, 0),
             )
         except Exception:
             pass  # pipeline will fail further on; we only care the warning fired
 
 def test_run_pipeline_requires_scale_or_align():
-    """Neither scale nor transform provided should raise."""
-    with pytest.raises(ValueError, match='scale.*transform'):
+    """Neither scale nor align_transform provided should raise."""
+    with pytest.raises(ValueError, match='scale.*align_transform'):
         run_pipeline(
             image_list=[MagicMock()],
             output_path='/tmp/test',
@@ -205,7 +205,7 @@ def test_run_pipeline_requires_scale_or_align():
         )
 
 def test_grid_and_run_pipeline_requires_stride():
-    """stride is required for grid sampling even when transform supplies pixel size."""
+    """stride is required for grid sampling even when align_transform supplies pixel size."""
     with pytest.raises(ValueError, match='stride'):
         grid_and_run_pipeline(
             image_list=[MagicMock()],
@@ -213,7 +213,7 @@ def test_grid_and_run_pipeline_requires_stride():
             output_path='/tmp/test',
             project='test-project',
             patch_size=4,
-            transform=Affine(0.001, 0, 0, 0, -0.001, 0),
+            align_transform=Affine(0.001, 0, 0, 0, -0.001, 0),
         )
 
 def test_run_pipeline_rejects_image_collection():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -204,18 +204,6 @@ def test_run_pipeline_requires_scale_or_align():
             sampling_points=MagicMock(),
         )
 
-def test_grid_and_run_pipeline_requires_stride():
-    """stride is required for grid sampling even when align_transform supplies pixel size."""
-    with pytest.raises(ValueError, match='stride'):
-        grid_and_run_pipeline(
-            image_list=[MagicMock()],
-            sampling_region=MagicMock(),
-            output_path='/tmp/test',
-            project='test-project',
-            patch_size=4,
-            align_transform=Affine(0.001, 0, 0, 0, -0.001, 0),
-        )
-
 def test_run_pipeline_rejects_image_collection():
     """An ee.ImageCollection passed as image_list should raise ValueError."""
     with pytest.raises(ValueError, match='ee.ImageCollection'):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -65,7 +65,7 @@ def test_type_inference_str():
     assert _type_inference('hello') == 'str'
 
 def test_type_inference_invalid():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         _type_inference({'key': 'value'})
 
 def test_build_md_feature_dict_basic():
@@ -84,7 +84,7 @@ def test_build_md_feature_dict_with_extra_metadata():
 def test_build_md_feature_dict_invalid_type():
     record = {'id': 1, 'x': 10.0, 'y': 20.0, 'split': 'train'}
     extra_metadata = {'bad': {'nested': 'dict'}}
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         _build_md_feature_dict(record, extra_metadata)
 
 PATCH_SIZE = 10
@@ -167,7 +167,7 @@ def test_run_pipeline_wraps_single_image(mock_projection, mock_ee_init):
 
     single_image = MagicMock(spec=ee.Image)
     with (pytest.warns(UserWarning, match='Wrapping provided single ee.Image'),
-          pytest.raises(ValueError)):
+          pytest.raises(TypeError)):
             run_pipeline(
                 image_list=single_image,
                 output_path='/tmp/test',
@@ -180,7 +180,7 @@ def test_run_pipeline_wraps_single_image(mock_projection, mock_ee_init):
 def test_run_pipeline_transform_warns_scale_ignored():
     """Passing align_transform should warn that `scale` is ignored."""
     with (pytest.warns(UserWarning, match='`scale` argument is ignored'),
-          pytest.raises(ValueError)):
+          pytest.raises(TypeError)):
                 run_pipeline(
                     image_list=[MagicMock()],
                     output_path='/tmp/test',
@@ -203,8 +203,8 @@ def test_run_pipeline_requires_scale_or_align():
         )
 
 def test_run_pipeline_rejects_image_collection():
-    """An ee.ImageCollection passed as image_list should raise ValueError."""
-    with pytest.raises(ValueError, match='ee.ImageCollection'):
+    """An ee.ImageCollection passed as image_list should raise TypeError."""
+    with pytest.raises(TypeError, match='ee.ImageCollection'):
         run_pipeline(
             image_list=MagicMock(spec=ee.ImageCollection),
             output_path='/tmp/test',
@@ -215,7 +215,7 @@ def test_run_pipeline_rejects_image_collection():
         )
 
 def test_run_pipeline_invalid_output_type():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         run_pipeline(
             image_list=[MagicMock()],
             output_path='/tmp/test',

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -166,8 +166,8 @@ def test_run_pipeline_wraps_single_image(mock_projection, mock_ee_init):
     mock_projection.return_value.atScale.return_value = mock_proj_obj
 
     single_image = MagicMock(spec=ee.Image)
-    with pytest.warns(UserWarning, match='Wrapping provided single ee.Image'):
-        try:
+    with (pytest.warns(UserWarning, match='Wrapping provided single ee.Image'),
+          pytest.raises(ValueError)):
             run_pipeline(
                 image_list=single_image,
                 output_path='/tmp/test',
@@ -176,24 +176,20 @@ def test_run_pipeline_wraps_single_image(mock_projection, mock_ee_init):
                 scale=30.0,
                 sampling_points=MagicMock(),
             )
-        except Exception:
-            pass  # pipeline will fail further on; we only care the warning fired
 
 def test_run_pipeline_transform_warns_scale_ignored():
     """Passing align_transform should warn that `scale` is ignored."""
-    with pytest.warns(UserWarning, match='`scale` argument is ignored'):
-        try:
-            run_pipeline(
-                image_list=[MagicMock()],
-                output_path='/tmp/test',
-                project='test-project',
-                patch_size=4,
-                scale=30.0,
-                sampling_points=MagicMock(),
-                align_transform=Affine(0.001, 0, 0, 0, -0.001, 0),
-            )
-        except Exception:
-            pass  # pipeline will fail further on; we only care the warning fired
+    with (pytest.warns(UserWarning, match='`scale` argument is ignored'),
+          pytest.raises(ValueError)):
+                run_pipeline(
+                    image_list=[MagicMock()],
+                    output_path='/tmp/test',
+                    project='test-project',
+                    patch_size=4,
+                    scale=30.0,
+                    sampling_points=MagicMock(),
+                    align_transform=Affine(0.001, 0, 0, 0, -0.001, 0),
+                )
 
 def test_run_pipeline_requires_scale_or_align():
     """Neither scale nor align_transform provided should raise."""

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -10,7 +10,6 @@ from geebeam.pipeline import (
     _type_inference,
     _build_md_feature_dict,
     run_pipeline,
-    grid_and_run_pipeline,
 )
 from apache_beam.options.pipeline_options import PipelineOptions
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 import ee
+from rasterio.transform import Affine
 from unittest.mock import patch, MagicMock
 from geebeam.pipeline import (
     _prepare_run_metadata,
@@ -9,6 +10,7 @@ from geebeam.pipeline import (
     _type_inference,
     _build_md_feature_dict,
     run_pipeline,
+    grid_and_run_pipeline,
 )
 from apache_beam.options.pipeline_options import PipelineOptions
 
@@ -123,6 +125,36 @@ def test_apply_position_offset_invalid_position():
     with pytest.raises(ValueError, match='Invalid position'):
         _apply_position_offset(records, 'middle', PATCH_SIZE, SCALE_X, SCALE_Y)
 
+@pytest.mark.parametrize('position', ['top-left', 'top-right', 'bottom-left', 'bottom-right', 'center'])
+@pytest.mark.parametrize('patch_size', [4, 5])  # even and odd
+def test_apply_position_offset_align_snaps_topleft(position, patch_size):
+    """With transform, the top-left corner must land exactly on the reference grid,
+    for any position and any (even/odd) patch_size."""
+    # origin (0, 0), pixel size 1.0 -> grid nodes are integers
+    align = Affine(1.0, 0, 0.0, 0, -1.0, 0.0)
+    records = [{'id': 0, 'x': 3.37, 'y': 8.62, 'split': 'full'}]
+    result = _apply_position_offset(records, position, patch_size, 1.0, 1.0,
+                                    transform=align)
+    x_tl, y_tl = result[0]['x_topleft'], result[0]['y_topleft']
+    assert x_tl == round(x_tl)
+    assert y_tl == round(y_tl)
+    # original x/y preserved
+    assert result[0]['x'] == 3.37
+    assert result[0]['y'] == 8.62
+
+@patch('ee.Initialize')
+@patch('ee.Projection')
+def test_prepare_run_metadata_align_overrides_scale(mock_projection, mock_ee_init):
+    """transform pixel size overrides scale; ee.Projection should not be consulted."""
+    config = {'project_id': 'test-project', 'crs': 'EPSG:4326', 'scale': 30}
+    align = Affine(0.25, 0, 100.0, 0, -0.5, 200.0)
+
+    scale_x, scale_y = _prepare_run_metadata(config, transform=align)
+
+    assert scale_x == 0.25
+    assert scale_y == 0.5  # abs(-0.5)
+    mock_projection.assert_not_called()
+
 @patch('ee.Initialize')
 @patch('ee.Projection')
 def test_run_pipeline_wraps_single_image(mock_projection, mock_ee_init):
@@ -144,6 +176,45 @@ def test_run_pipeline_wraps_single_image(mock_projection, mock_ee_init):
             )
         except Exception:
             pass  # pipeline will fail further on; we only care the warning fired
+
+def test_run_pipeline_transform_warns_scale_ignored():
+    """Passing transform should warn that `scale` is ignored."""
+    with pytest.warns(UserWarning, match='`scale` argument is ignored'):
+        try:
+            run_pipeline(
+                image_list=[MagicMock()],
+                output_path='/tmp/test',
+                project='test-project',
+                patch_size=4,
+                scale=30.0,
+                sampling_points=MagicMock(),
+                transform=Affine(0.001, 0, 0, 0, -0.001, 0),
+            )
+        except Exception:
+            pass  # pipeline will fail further on; we only care the warning fired
+
+def test_run_pipeline_requires_scale_or_align():
+    """Neither scale nor transform provided should raise."""
+    with pytest.raises(ValueError, match='scale.*transform'):
+        run_pipeline(
+            image_list=[MagicMock()],
+            output_path='/tmp/test',
+            project='test-project',
+            patch_size=4,
+            sampling_points=MagicMock(),
+        )
+
+def test_grid_and_run_pipeline_requires_stride():
+    """stride is required for grid sampling even when transform supplies pixel size."""
+    with pytest.raises(ValueError, match='stride'):
+        grid_and_run_pipeline(
+            image_list=[MagicMock()],
+            sampling_region=MagicMock(),
+            output_path='/tmp/test',
+            project='test-project',
+            patch_size=4,
+            transform=Affine(0.001, 0, 0, 0, -0.001, 0),
+        )
 
 def test_run_pipeline_rejects_image_collection():
     """An ee.ImageCollection passed as image_list should raise ValueError."""

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,17 +1,20 @@
-import pytest
-import numpy as np
+from unittest.mock import MagicMock, patch
+
 import ee
+import numpy as np
+import pytest
+from apache_beam.options.pipeline_options import PipelineOptions
 from rasterio.transform import Affine
-from unittest.mock import patch, MagicMock
+
 from geebeam.pipeline import (
-    _prepare_run_metadata,
     _apply_position_offset,
-    _check_if_localrunner,
-    _type_inference,
     _build_md_feature_dict,
+    _check_if_localrunner,
+    _prepare_run_metadata,
+    _type_inference,
     run_pipeline,
 )
-from apache_beam.options.pipeline_options import PipelineOptions
+
 
 @patch('ee.Initialize')
 @patch('ee.Projection')

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,19 +1,22 @@
-import pytest
+from unittest.mock import MagicMock, patch
+
+import geopandas as gpd
 import numpy as np
 import pandas as pd
-import geopandas as gpd
-from shapely.geometry import box
+import pytest
 from rasterio.transform import Affine
-from unittest.mock import MagicMock, patch
+from shapely.geometry import box
+
 from geebeam.sampler import (
+    _get_roi,
+    _parse_transform,
+    _process_sampling_points,
+    _snap_to_grid,
+    sample_region_grid,
     sample_region_random,
     split_sets,
-    _process_sampling_points,
-    _get_roi,
-    sample_region_grid,
-    _parse_transform,
-    _snap_to_grid,
 )
+
 
 def test_split_sets():
     df = pd.DataFrame({

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -191,7 +191,7 @@ def test_sample_region_grid_transform():
     # origin (0.05, 0.05), pixel size 0.1; align mode should NOT call _get_crs_scale
     align = Affine(0.1, 0, 0.05, 0, -0.1, 0.05)
     result = sample_region_grid(roi=roi_gdf, crs='EPSG:4326', stride=1, scale=1000.0,
-                                transform=align)
+                                align_transform=align)
     assert len(result) > 0
     kx = (result.geometry.x.values - 0.05) / 0.1
     ky = (result.geometry.y.values - 0.05) / 0.1
@@ -199,10 +199,11 @@ def test_sample_region_grid_transform():
     assert np.allclose(ky, np.round(ky))
 
 def test_sample_region_grid_align_no_scale():
-    """transform supplies pixel size, so scale can be omitted."""
+    """align_transform supplies pixel size, so scale can be omitted."""
     roi_gdf = gpd.GeoDataFrame(geometry=[box(0.0, 0.0, 1.0, 1.0)], crs='EPSG:4326')
     align = Affine(0.1, 0, 0.05, 0, -0.1, 0.05)
-    result = sample_region_grid(roi=roi_gdf, crs='EPSG:4326', stride=1, transform=align)
+    result = sample_region_grid(roi=roi_gdf, crs='EPSG:4326', stride=1,
+                                align_transform=align)
     assert len(result) > 0
     kx = (result.geometry.x.values - 0.05) / 0.1
     assert np.allclose(kx, np.round(kx))
@@ -220,7 +221,7 @@ def test_sample_region_random_transform_snaps_points():
     mock_roi.crs.to_string.return_value = 'EPSG:4326'
 
     align = Affine(5.0, 0, 0.0, 0, -5.0, 0.0)
-    result = sample_region_random(mock_roi, 'EPSG:4326', 2, transform=align)
+    result = sample_region_random(mock_roi, 'EPSG:4326', 2, align_transform=align)
 
     assert list(result.geometry.x) == [10.0, 30.0]
     assert list(result.geometry.y) == [50.0, 65.0]
@@ -234,7 +235,7 @@ def test_sample_region_random_transform_warns_on_collision():
 
     align = Affine(5.0, 0, 0.0, 0, -5.0, 0.0)
     with pytest.warns(UserWarning, match='duplicate locations'):
-        result = sample_region_random(mock_roi, 'EPSG:4326', 2, transform=align)
+        result = sample_region_random(mock_roi, 'EPSG:4326', 2, align_transform=align)
     # both collapsed onto (10, 50)
     assert list(result.geometry.x) == [10.0, 10.0]
     assert list(result.geometry.y) == [50.0, 50.0]

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,7 +1,9 @@
 import pytest
+import numpy as np
 import pandas as pd
 import geopandas as gpd
 from shapely.geometry import box
+from rasterio.transform import Affine
 from unittest.mock import MagicMock, patch
 from geebeam.sampler import (
     sample_region_random,
@@ -9,6 +11,8 @@ from geebeam.sampler import (
     _process_sampling_points,
     _get_roi,
     sample_region_grid,
+    _parse_transform,
+    _snap_to_grid,
 )
 
 def test_split_sets():
@@ -151,3 +155,86 @@ def test_split_sets_empty_split_names():
     df = pd.DataFrame({'x': range(5), 'y': range(5)})
     result = split_sets(df, split_names=[])
     assert (result['split'] == 'full').all()
+
+def test_parse_transform_affine_and_tuple_match():
+    affine = Affine(30.0, 0, 500000.0, 0, -30.0, 4500000.0)
+    tup = (30.0, 0, 500000.0, 0, -30.0, 4500000.0)
+    assert _parse_transform(affine) == _parse_transform(tup)
+    x0, y0, sx, sy = _parse_transform(affine)
+    assert (x0, y0) == (500000.0, 4500000.0)
+    # scale_x/scale_y are positive magnitudes (matches scale_y = -transform[4] convention)
+    assert (sx, sy) == (30.0, 30.0)
+
+def test_parse_transform_rejects_shear():
+    with pytest.raises(ValueError, match='shear'):
+        _parse_transform((30.0, 0.1, 0.0, 0.0, -30.0, 0.0))
+    with pytest.raises(ValueError, match='shear'):
+        _parse_transform((30.0, 0.0, 0.0, 0.2, -30.0, 0.0))
+
+def test_snap_to_grid_scalar():
+    # origin (0, 0), pixel size 5 -> nearest multiple of 5
+    x, y = _snap_to_grid(12.3, 63.9, 0.0, 0.0, 5.0, 5.0)
+    assert x == 10.0
+    assert y == 65.0
+    assert isinstance(x, float) and isinstance(y, float)
+
+def test_snap_to_grid_array_and_offset_origin():
+    xs = np.array([12.3, 27.6])
+    ys = np.array([51.1, 63.9])
+    xs_snap, ys_snap = _snap_to_grid(xs, ys, 1.0, 1.0, 5.0, 5.0)
+    # nodes must satisfy (v - origin) / pixel == integer
+    assert np.allclose((xs_snap - 1.0) / 5.0, np.round((xs_snap - 1.0) / 5.0))
+    assert np.allclose((ys_snap - 1.0) / 5.0, np.round((ys_snap - 1.0) / 5.0))
+
+def test_sample_region_grid_transform():
+    roi_gdf = gpd.GeoDataFrame(geometry=[box(0.0, 0.0, 1.0, 1.0)], crs='EPSG:4326')
+    # origin (0.05, 0.05), pixel size 0.1; align mode should NOT call _get_crs_scale
+    align = Affine(0.1, 0, 0.05, 0, -0.1, 0.05)
+    result = sample_region_grid(roi=roi_gdf, crs='EPSG:4326', stride=1, scale=1000.0,
+                                transform=align)
+    assert len(result) > 0
+    kx = (result.geometry.x.values - 0.05) / 0.1
+    ky = (result.geometry.y.values - 0.05) / 0.1
+    assert np.allclose(kx, np.round(kx))
+    assert np.allclose(ky, np.round(ky))
+
+def test_sample_region_grid_align_no_scale():
+    """transform supplies pixel size, so scale can be omitted."""
+    roi_gdf = gpd.GeoDataFrame(geometry=[box(0.0, 0.0, 1.0, 1.0)], crs='EPSG:4326')
+    align = Affine(0.1, 0, 0.05, 0, -0.1, 0.05)
+    result = sample_region_grid(roi=roi_gdf, crs='EPSG:4326', stride=1, transform=align)
+    assert len(result) > 0
+    kx = (result.geometry.x.values - 0.05) / 0.1
+    assert np.allclose(kx, np.round(kx))
+
+def test_sample_region_grid_requires_scale():
+    """Without transform, scale is required."""
+    roi_gdf = gpd.GeoDataFrame(geometry=[box(0.0, 0.0, 1.0, 1.0)], crs='EPSG:4326')
+    with pytest.raises(ValueError, match='scale'):
+        sample_region_grid(roi=roi_gdf, crs='EPSG:4326', stride=1)
+
+def test_sample_region_random_transform_snaps_points():
+    mock_roi = MagicMock(spec=gpd.GeoDataFrame)
+    mock_points = gpd.points_from_xy([12.3, 27.6], [51.1, 63.9], crs='EPSG:4326')
+    mock_roi.sample_points.return_value.geometry.explode.return_value = mock_points
+    mock_roi.crs.to_string.return_value = 'EPSG:4326'
+
+    align = Affine(5.0, 0, 0.0, 0, -5.0, 0.0)
+    result = sample_region_random(mock_roi, 'EPSG:4326', 2, transform=align)
+
+    assert list(result.geometry.x) == [10.0, 30.0]
+    assert list(result.geometry.y) == [50.0, 65.0]
+
+def test_sample_region_random_transform_warns_on_collision():
+    mock_roi = MagicMock(spec=gpd.GeoDataFrame)
+    # Two nearby points snap to the same coarse grid node -> collision
+    mock_points = gpd.points_from_xy([12.1, 12.4], [50.2, 49.8], crs='EPSG:4326')
+    mock_roi.sample_points.return_value.geometry.explode.return_value = mock_points
+    mock_roi.crs.to_string.return_value = 'EPSG:4326'
+
+    align = Affine(5.0, 0, 0.0, 0, -5.0, 0.0)
+    with pytest.warns(UserWarning, match='duplicate locations'):
+        result = sample_region_random(mock_roi, 'EPSG:4326', 2, transform=align)
+    # both collapsed onto (10, 50)
+    assert list(result.geometry.x) == [10.0, 10.0]
+    assert list(result.geometry.y) == [50.0, 50.0]

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -50,7 +50,7 @@ def test_process_sampling_points_geodataframe():
 
 def test_process_sampling_points_dataframe():
     df = pd.DataFrame({'x': [10.0, 20.0], 'y': [50.0, 60.0]})
-    records, splits = _process_sampling_points(df, 'EPSG:4326')
+    records, _splits = _process_sampling_points(df, 'EPSG:4326')
     assert len(records) == 2
     assert records[0]['x'] == 10.0
     assert records[0]['y'] == 50.0

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -71,7 +71,7 @@ def test_process_sampling_points_dataframe_missing_xy():
         _process_sampling_points(df, 'EPSG:4326')
 
 def test_process_sampling_points_invalid_type():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         _process_sampling_points({'x': 10, 'y': 20}, 'EPSG:4326')
 
 def test_process_sampling_points_adds_id_and_split():
@@ -108,7 +108,7 @@ def test_get_roi_string():
         mock_read_file.assert_called_once_with('/fake/path/file.gpkg')
 
 def test_get_roi_invalid():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         _get_roi(12345, 'EPSG:4326')
 
 def test_sample_region_grid():

--- a/tests/test_tf_utils.py
+++ b/tests/test_tf_utils.py
@@ -1,6 +1,13 @@
-import tensorflow as tf
 import numpy as np
-from geebeam._tf_utils import _bytes_feature, _float_feature, _int64_feature, _dict_to_example
+import tensorflow as tf
+
+from geebeam._tf_utils import (
+    _bytes_feature,
+    _dict_to_example,
+    _float_feature,
+    _int64_feature,
+)
+
 
 def test_features():
     assert isinstance(_bytes_feature(b'test'), tf.train.Feature)

--- a/tests/test_tiff_writer.py
+++ b/tests/test_tiff_writer.py
@@ -1,8 +1,10 @@
 import os
-import pytest
+
 import numpy as np
+import pytest
 import rasterio
-from geebeam._tiff_writer import _build_tiff_name, WriteTiff, ProcessMetadataToParquet
+
+from geebeam._tiff_writer import ProcessMetadataToParquet, WriteTiff, _build_tiff_name
 
 
 def test_build_tiff_name():

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,14 +1,17 @@
 import json
-import numpy as np
 from unittest.mock import MagicMock, patch
+
+import numpy as np
+
 from geebeam._transforms import (
-    _split_dataset,
+    AddMetadata,
     _convert_to_iterable,
+    _join_struct_arrays_to_dict,
+    _split_dataset,
     _write_sidecar_schema,
     join_structured_arrays,
-    _join_struct_arrays_to_dict,
-    AddMetadata,
 )
+
 
 def test__split_dataset():
     element = {'metadata': {'split': 'train'}}

--- a/tests/test_wds_writer.py
+++ b/tests/test_wds_writer.py
@@ -1,8 +1,11 @@
 import io
 import json
+
 import numpy as np
 import rasterio
-from geebeam._wds_writer import _create_tiff_bytes, ProcessToWebDataset
+
+from geebeam._wds_writer import ProcessToWebDataset, _create_tiff_bytes
+
 
 def test_create_tiff_bytes():
     array_dict = {


### PR DESCRIPTION
Sampling and pipeline methods now allow for specifying align_transform=(a,b,c,d,e,f). If provided:
- Sampled points are snapped to the transform grid to avoid extra reprojections/sampling errors.
- scale is taken from align_transform. If scale is also provided, raises a warning.
- Shear is not supported as of now.